### PR TITLE
Allows to choose the target account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,4 @@ META-INF
 
 out/config.properties
 
-lib/aws-java-sdk-1.10.71.jar
-
-lib/aws-java-sdk-1.10.74.jar
-
-lib/aws-java-sdk-1.11.37.jar
+lib/aws-java-sdk-*.jar

--- a/.idea/libraries/aws_java_sdk_1_11_59.xml
+++ b/.idea/libraries/aws_java_sdk_1_11_59.xml
@@ -1,7 +1,7 @@
 <component name="libraryTable">
-  <library name="aws-java-sdk-1.11.37">
+  <library name="aws-java-sdk-1.11.59">
     <CLASSES>
-      <root url="jar://$PROJECT_DIR$/lib/aws-java-sdk-1.11.37.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/aws-java-sdk-1.11.59.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/okta-aws-cli.iml
+++ b/okta-aws-cli.iml
@@ -18,6 +18,6 @@
     <orderEntry type="library" name="okta-sdk" level="project" />
     <orderEntry type="library" name="joda-time-2.9.3" level="project" />
     <orderEntry type="library" name="org.apache.logging.log4j:log4j-core:2.6.2" level="project" />
-    <orderEntry type="library" name="aws-java-sdk-1.11.37" level="project" />
+    <orderEntry type="library" name="aws-java-sdk-1.11.59" level="project" />
   </component>
 </module>

--- a/out/awscli.bat
+++ b/out/awscli.bat
@@ -1,1 +1,1 @@
-java -classpath oktaawscli.jar;../lib/aws-java-sdk-1.10.74.jar com.okta.tools.awscli
+java -classpath oktaawscli.jar;../lib/aws-java-sdk-1.11.59.jar com.okta.tools.awscli

--- a/out/awscli.command
+++ b/out/awscli.command
@@ -1,1 +1,1 @@
-java -classpath .:oktaawscli.jar:../lib/aws-java-sdk-1.11.37.jar com.okta.tools.awscli
+java -classpath .:oktaawscli.jar:../lib/aws-java-sdk-1.11.59.jar com.okta.tools.awscli


### PR DESCRIPTION
If cross-account role is linked to multiple accounts.
Will assume the existing role by default if the cross-account role is linked to only one account.